### PR TITLE
feat(queue) : queue module implementation

### DIFF
--- a/backend/src/database/models/Queue.js
+++ b/backend/src/database/models/Queue.js
@@ -1,0 +1,65 @@
+import mongoose from 'mongoose';
+
+const queueSchema = new mongoose.Schema(
+  {
+    branch: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Branch',
+      required: true,
+      index: true,
+    },
+
+    status: {
+      type: String,
+      enum: ['ACTIVE', 'CLOSED'],
+      default: 'ACTIVE',
+      index: true,
+    },
+
+    // Current token being called
+    currentToken: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Token',
+      default: null,
+    },
+
+    // Queue lifecycle tracking
+    openedAt: {
+      type: Date,
+      default: Date.now,
+    },
+
+    openedBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+    },
+
+    closedAt: {
+      type: Date,
+      default: null,
+    },
+
+    closedBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+    },
+
+    // Monitoring
+    lastCalledAt: {
+      type: Date,
+      default: null,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+// Prevent duplicate active queues per branch per day (logical rule)
+queueSchema.index(
+  { branch: 1, status: 1, createdAt: 1 },
+  { name: 'branch_status_createdAt_idx' }
+);
+
+const Queue = mongoose.model('Queue', queueSchema);
+export default Queue;

--- a/backend/src/modules/queue/controller.js
+++ b/backend/src/modules/queue/controller.js
@@ -1,0 +1,56 @@
+import ApiResponse from '../../core/apiResponse.js';
+import asyncHandler from '../../utils/asyncHandler.js';
+
+import {
+  openQueue,
+  closeQueue,
+  getActiveQueue,
+  callNextToken,
+  markServed,
+  markNoShow,
+  listQueues,
+} from './service.js';
+
+export const open = asyncHandler(async (req, res) => {
+  const queue = await openQueue({ branchId: req.body.branchId, userId: req.user?.id });
+  return new ApiResponse(201, 'Queue opened', queue).send(res);
+});
+
+export const close = asyncHandler(async (req, res) => {
+  const queue = await closeQueue({ branchId: req.body.branchId, userId: req.user?.id });
+  return new ApiResponse(200, 'Queue closed', queue).send(res);
+});
+
+export const active = asyncHandler(async (req, res) => {
+  const queue = await getActiveQueue(req.params.branchId);
+  return new ApiResponse(200, 'Active queue', queue).send(res);
+});
+
+export const next = asyncHandler(async (req, res) => {
+  const token = await callNextToken({
+    branchId: req.body.branchId,
+    counterId: req.body.counterId,
+    userId: req.user?.id,
+  });
+  return new ApiResponse(200, 'Next token called', token).send(res);
+});
+
+export const served = asyncHandler(async (req, res) => {
+  const token = await markServed({ tokenId: req.params.tokenId, userId: req.user?.id });
+  return new ApiResponse(200, 'Token marked served', token).send(res);
+});
+
+export const noShow = asyncHandler(async (req, res) => {
+  const token = await markNoShow({ tokenId: req.params.tokenId, userId: req.user?.id });
+  return new ApiResponse(200, 'Token marked no-show', token).send(res);
+});
+
+export const list = asyncHandler(async (req, res) => {
+  const data = await listQueues({
+    branchId: req.query.branchId,
+    status: req.query.status,
+    page: req.query.page,
+    limit: req.query.limit,
+  });
+  return new ApiResponse(200, 'Queues list', data).send(res);
+});

--- a/backend/src/modules/queue/routes.js
+++ b/backend/src/modules/queue/routes.js
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import { auth } from '../../middleware/auth.js';
+import { allowRoles } from '../../middleware/role.js';
+import { ROLES } from '../../core/constants.js';
+
+import * as controller from './controller.js';
+import {
+  validateOpenQueue,
+  validateCloseQueue,
+  validateGetActiveQueue,
+  validateCallNext,
+  validateTokenAction,
+} from './validation.js';
+
+const router = Router();
+
+router.post('/open', auth, allowRoles(ROLES.ADMIN, ROLES.STAFF), validateOpenQueue, controller.open);
+router.patch('/close', auth, allowRoles(ROLES.ADMIN, ROLES.STAFF), validateCloseQueue, controller.close);
+
+router.get('/active/:branchId', auth, allowRoles(ROLES.ADMIN, ROLES.STAFF), validateGetActiveQueue, controller.active);
+
+router.post('/next', auth, allowRoles(ROLES.ADMIN, ROLES.STAFF), validateCallNext, controller.next);
+
+router.patch('/tokens/:tokenId/served', auth, allowRoles(ROLES.ADMIN, ROLES.STAFF), validateTokenAction, controller.served);
+router.patch('/tokens/:tokenId/no-show', auth, allowRoles(ROLES.ADMIN, ROLES.STAFF), validateTokenAction, controller.noShow);
+
+router.get('/', auth, allowRoles(ROLES.ADMIN, ROLES.STAFF), controller.list);
+
+export default router;

--- a/backend/src/modules/queue/service.js
+++ b/backend/src/modules/queue/service.js
@@ -1,0 +1,186 @@
+import mongoose from 'mongoose';
+import ApiError from '../../core/apiError.js';
+
+import Queue from '../../database/models/Queue.js';
+import Token from '../../database/models/Token.js';
+import Branch from '../../database/models/Branch.js';
+import Counter from '../../database/models/Counter.js';
+
+const QUEUE_STATUS = {
+  ACTIVE: 'ACTIVE',
+  CLOSED: 'CLOSED',
+};
+
+const TOKEN_STATUS = {
+  WAITING: 'WAITING',
+  CALLED: 'CALLED',
+  SERVED: 'SERVED',
+  NO_SHOW: 'NO_SHOW',
+};
+
+const startOfToday = () => {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+};
+
+const endOfToday = () => {
+  const d = new Date();
+  d.setHours(23, 59, 59, 999);
+  return d;
+};
+
+export const openQueue = async ({ branchId, userId }) => {
+  const branch = await Branch.findById(branchId);
+  if (!branch) throw new ApiError(404, 'Branch not found');
+
+  // One active queue per day per branch
+  const existing = await Queue.findOne({
+    branch: branchId,
+    status: QUEUE_STATUS.ACTIVE,
+    createdAt: { $gte: startOfToday(), $lte: endOfToday() },
+  });
+
+  if (existing) return existing;
+
+  const queue = await Queue.create({
+    branch: branchId,
+    status: QUEUE_STATUS.ACTIVE,
+    openedBy: userId,
+    openedAt: new Date(),
+  });
+
+  return queue;
+};
+
+export const closeQueue = async ({ branchId, userId }) => {
+  const queue = await Queue.findOne({
+    branch: branchId,
+    status: QUEUE_STATUS.ACTIVE,
+    createdAt: { $gte: startOfToday(), $lte: endOfToday() },
+  });
+
+  if (!queue) throw new ApiError(404, 'No active queue found for this branch today');
+
+  queue.status = QUEUE_STATUS.CLOSED;
+  queue.closedBy = userId;
+  queue.closedAt = new Date();
+  await queue.save();
+
+  return queue;
+};
+
+export const getActiveQueue = async (branchId) => {
+  const queue = await Queue.findOne({
+    branch: branchId,
+    status: QUEUE_STATUS.ACTIVE,
+    createdAt: { $gte: startOfToday(), $lte: endOfToday() },
+  }).populate('branch');
+
+  if (!queue) throw new ApiError(404, 'No active queue found');
+  return queue;
+};
+
+export const callNextToken = async ({ branchId, counterId, userId }) => {
+  const counter = await Counter.findById(counterId);
+  if (!counter) throw new ApiError(404, 'Counter not found');
+  if (String(counter.branch) !== String(branchId)) throw new ApiError(400, 'Counter does not belong to this branch');
+  if (counter.isActive === false) throw new ApiError(400, 'Counter is not active');
+
+  const queue = await Queue.findOne({
+    branch: branchId,
+    status: QUEUE_STATUS.ACTIVE,
+    createdAt: { $gte: startOfToday(), $lte: endOfToday() },
+  });
+
+  if (!queue) throw new ApiError(404, 'No active queue found for this branch today');
+
+  // Use transaction to reduce race conditions (two counters calling next at same time)
+  const session = await mongoose.startSession();
+  session.startTransaction();
+
+  try {
+    const token = await Token.findOne({
+      branch: branchId,
+      queue: queue._id,
+      status: TOKEN_STATUS.WAITING,
+    })
+      .sort({ number: 1, createdAt: 1 })
+      .session(session);
+
+    if (!token) throw new ApiError(404, 'No waiting tokens');
+
+    token.status = TOKEN_STATUS.CALLED;
+    token.calledAt = new Date();
+    token.calledBy = userId;
+    token.counter = counterId;
+
+    await token.save({ session });
+
+    queue.currentToken = token._id;
+    queue.lastCalledAt = new Date();
+    await queue.save({ session });
+
+    await session.commitTransaction();
+    session.endSession();
+
+    return await Token.findById(token._id).populate('counter').populate('branch');
+  } catch (err) {
+    await session.abortTransaction();
+    session.endSession();
+    throw err;
+  }
+};
+
+export const markServed = async ({ tokenId, userId }) => {
+  const token = await Token.findById(tokenId);
+  if (!token) throw new ApiError(404, 'Token not found');
+
+  if (![TOKEN_STATUS.CALLED, TOKEN_STATUS.WAITING].includes(token.status)) {
+    throw new ApiError(400, `Token cannot be marked served from status: ${token.status}`);
+  }
+
+  token.status = TOKEN_STATUS.SERVED;
+  token.servedAt = new Date();
+  token.servedBy = userId;
+
+  await token.save();
+  return token;
+};
+
+export const markNoShow = async ({ tokenId, userId }) => {
+  const token = await Token.findById(tokenId);
+  if (!token) throw new ApiError(404, 'Token not found');
+
+  if (![TOKEN_STATUS.CALLED].includes(token.status)) {
+    throw new ApiError(400, `Token cannot be marked no-show from status: ${token.status}`);
+  }
+
+  token.status = TOKEN_STATUS.NO_SHOW;
+  token.noShowAt = new Date();
+  token.noShowBy = userId;
+
+  await token.save();
+  return token;
+};
+
+export const listQueues = async ({ branchId, status, page = 1, limit = 10 }) => {
+  const q = {};
+  if (branchId) q.branch = branchId;
+  if (status) q.status = status;
+
+  const skip = (Number(page) - 1) * Number(limit);
+
+  const [items, total] = await Promise.all([
+    Queue.find(q).sort({ createdAt: -1 }).skip(skip).limit(Number(limit)).populate('branch'),
+    Queue.countDocuments(q),
+  ]);
+
+  return {
+    items,
+    total,
+    page: Number(page),
+    limit: Number(limit),
+    totalPages: Math.ceil(total / Number(limit)) || 1,
+  };
+};

--- a/backend/src/modules/queue/validation.js
+++ b/backend/src/modules/queue/validation.js
@@ -1,0 +1,34 @@
+import ApiError from '../../core/apiError.js';
+
+const isValidObjectId = (id) => /^[0-9a-fA-F]{24}$/.test(String(id || ''));
+
+export const validateOpenQueue = (req, _res, next) => {
+  const { branchId } = req.body;
+  if (!isValidObjectId(branchId)) return next(new ApiError(400, 'Valid branchId is required'));
+  next();
+};
+
+export const validateCloseQueue = (req, _res, next) => {
+  const { branchId } = req.body;
+  if (!isValidObjectId(branchId)) return next(new ApiError(400, 'Valid branchId is required'));
+  next();
+};
+
+export const validateGetActiveQueue = (req, _res, next) => {
+  const { branchId } = req.params;
+  if (!isValidObjectId(branchId)) return next(new ApiError(400, 'Valid branchId is required'));
+  next();
+};
+
+export const validateCallNext = (req, _res, next) => {
+  const { branchId, counterId } = req.body;
+  if (!isValidObjectId(branchId)) return next(new ApiError(400, 'Valid branchId is required'));
+  if (!isValidObjectId(counterId)) return next(new ApiError(400, 'Valid counterId is required'));
+  next();
+};
+
+export const validateTokenAction = (req, _res, next) => {
+  const { tokenId } = req.params;
+  if (!isValidObjectId(tokenId)) return next(new ApiError(400, 'Valid tokenId is required'));
+  next();
+};

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -3,6 +3,7 @@ import statusRoute from "./status.route.js";
 import authRoutes from '../modules/auth/routes.js';
 import branchRoutes from '../modules/branch/routes.js';
 import counterRoutes from '../modules/counter/routes.js';
+import queueRoutes from '../modules/queue/routes.js';
 
 const router = Router();
 
@@ -10,5 +11,6 @@ router.use("/status", statusRoute);
 router.use('/auth', authRoutes);
 router.use('/branches', branchRoutes);
 router.use('/counters', counterRoutes);
+router.use('/queues', queueRoutes);
 
 export default router;


### PR DESCRIPTION
## What was added
- Implemented Queue module with open, close, and active queue APIs
- Added next-token calling flow with counter assignment
- Implemented token status transitions (CALLED → SERVED / NO_SHOW)
- Added request validations and route bindings

## How to test
Using Postman:
1. POST /queues/open
2. POST /tokens (create at least 3 tokens)
3. POST /queues/next
4. PATCH /queues/tokens/:id/served
5. PATCH /queues/close

## Notes
- Queue is opened once per branch per day
- Only ACTIVE queues allow token calling
- Endpoints are protected via auth middleware
- Uses Queue, Token, Counter, and Branch models