### PR TITLE
Use MongoMemoryReplSet for integration tests to support transactions

### DIFF
--- a/backend/src/tests/setup/testDB.js
+++ b/backend/src/tests/setup/testDB.js
@@ -1,13 +1,17 @@
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoMemoryReplSet } from "mongodb-memory-server";
 
-let mongo;
+let replset;
 
 export const connectTestDB = async () => {
-  mongo = await MongoMemoryServer.create();
-  const uri = mongo.getUri();
-
-  await mongoose.connect(uri);
+  replset = await MongoMemoryReplSet.create({
+    replSet: { count: 1 },
+  });
+  const uri = replset.getUri();
+  
+  await mongoose.connect(uri, {
+    dbName: "test",
+  });
 };
 
 export const clearTestDB = async () => {
@@ -18,7 +22,8 @@ export const clearTestDB = async () => {
 };
 
 export const closeTestDB = async () => {
-  await mongoose.connection.dropDatabase();
-  await mongoose.connection.close();
-  if (mongo) await mongo.stop();
+  await mongoose.disconnect();
+  if (replset) {
+    await replset.stop();
+  }
 };


### PR DESCRIPTION
## Summary
Switch integration test database setup from **MongoMemoryServer** to **MongoMemoryReplSet** to enable support for Mongoose transactions.

This change is required because parts of the queue flow (e.g. `callNextToken`) rely on `startSession()` and `startTransaction()`, which are only supported when MongoDB runs as a replica set.

---

## Changes
- Replaced `MongoMemoryServer` with `MongoMemoryReplSet`
- Updated test DB lifecycle utilities (`connect`, `clear`, `close`)
- Ensured in-memory MongoDB runs as a single-node replica set for tests

---

## Why
- MongoDB transactions are **not supported** in standalone mode
- Integration tests were failing or unreliable when exercising transaction-based logic
- Replica set mode matches production behavior more closely

---

## How to Test
```bash
npm run test:integration
