### PR TITLE
Fix rating unit test failures caused by invalid ObjectId usage (closes #42)

### DIFF
--- a/backend/src/tests/unit/rating.service.test.js
+++ b/backend/src/tests/unit/rating.service.test.js
@@ -1,4 +1,5 @@
 import { jest } from "@jest/globals";
+import mongoose from "mongoose";
 
 jest.unstable_mockModule("../../database/models/Token.js", () => ({
   default: {
@@ -177,6 +178,9 @@ describe("Rating Service (Unit) - ESM", () => {
   });
 
   describe("getRatingSummary()", () => {
+    const branchId = new mongoose.Types.ObjectId().toString();
+    const queueId = new mongoose.Types.ObjectId().toString();
+
     it("should return summary when aggregation returns data", async () => {
       ServiceRating.aggregate.mockResolvedValue([
         {
@@ -191,8 +195,8 @@ describe("Rating Service (Unit) - ESM", () => {
       ]);
 
       const out = await ratingService.getRatingSummary({
-        branchId: "b1",
-        queueId: "q1",
+        branchId,
+        queueId,
       });
 
       expect(out).toMatchObject({
@@ -206,8 +210,8 @@ describe("Rating Service (Unit) - ESM", () => {
       ServiceRating.aggregate.mockResolvedValue([]);
 
       const out = await ratingService.getRatingSummary({
-        branchId: "b1",
-        queueId: "q1",
+        branchId,
+        queueId,
       });
 
       expect(out).toEqual({


### PR DESCRIPTION
## Summary
This PR fixes failing unit tests in the **Rating Service** by correcting invalid MongoDB `ObjectId` values used in test cases.

The failures occurred because non-ObjectId strings were passed to `mongoose.Types.ObjectId`, causing BSON validation errors before mocked database calls were executed.

Closes #42 .
---

## Root Cause
- Unit tests passed placeholder IDs (e.g. `"b1"`, `"q1"`)
- `mongoose.Types.ObjectId()` requires valid 24-character hex strings
- Tests failed before reaching mocked `aggregate()` logic

---

## Changes
- Updated rating unit tests to use valid MongoDB `ObjectId` values
- Ensured `getRatingSummary()` tests correctly exercise aggregation logic
- No production code changes required

---

## Impact
- ✅ Rating unit tests now pass consistently
- ✅ Test behavior matches real runtime expectations
- ✅ CI pipeline stabilized

---

## Verification
```bash
npm run test:unit
