### PR TITLE
fix analytics integration tests error responses (closes #45)

### DIFF
--- a/backend/src/tests/integration/analytics.routes.test.js
+++ b/backend/src/tests/integration/analytics.routes.test.js
@@ -63,14 +63,15 @@ beforeAll(async () => {
     
   });
 
- analyticsRouter = (await import("../../modules/analytics/route.js")).default;
-
+  analyticsRouter = (await import("../../modules/analytics/routes.js")).default;
   Token = (await import("../../database/models/Token.js")).default;
   ServiceRating = (await import("../../database/models/ServiceRating.js")).default;
+  errorHandler = (await import("../../middleware/error.js")).default; 
 
   app = express();
   app.use(express.json());
   app.use("/api/analytics", analyticsRouter);
+  app.use(errorHandler);
 });
 
 afterEach(async () => {


### PR DESCRIPTION
### Overview
This PR resolves multiple failing analytics integration tests where `400 Bad Request` responses were returning empty JSON bodies instead of the expected structured error format.

The issue was isolated to the Express app setup used in integration tests, which did not fully mirror the production middleware chain.

Closes #45 .
---

### ❌ Problem
Several analytics integration tests were failing with assertions like:

```js
expect(res.body).toMatchObject({
  statusCode: 400,
  message: "Invalid branchId",
});
