### PR TITLE
Add Admin Layout with Sidebar & Topbar Navigation

### DIFF
--- a/frontend-web/src/app/routes/index.tsx
+++ b/frontend-web/src/app/routes/index.tsx
@@ -6,6 +6,7 @@ import LoginPage from "../../pages/LoginPage";
 import ProtectedRoute from "./ProtectedRoute";
 import RoleRoute from "./RoleRoute";
 import { ADMIN_PORTAL_ROLES } from "../../types/enums";
+import AdminLayout from "../../layouts/AdminLayout";
 
 export const router = createBrowserRouter([
   { path: "/login", element: <LoginPage /> },
@@ -15,9 +16,14 @@ export const router = createBrowserRouter([
     element: <ProtectedRoute />,
     children: [
       {
-        element: <RoleRoute allowed={ADMIN_PORTAL_ROLES} />,
+        element: <AdminLayout />,
         children: [
-          { path: "/", element: <HomePage /> },
+          {
+            element: <RoleRoute allowed={ADMIN_PORTAL_ROLES} />,
+            children: [
+              { path: "/", element: <HomePage /> },
+            ],
+          },
         ],
       },
     ],

--- a/frontend-web/src/components/common/ConfirmDialog.tsx
+++ b/frontend-web/src/components/common/ConfirmDialog.tsx
@@ -1,69 +1,107 @@
-type Props = {
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import { AlertTriangle, LogOut } from "lucide-react";
+
+type ConfirmDialogProps = {
   open: boolean;
   title?: string;
   message?: string;
   confirmText?: string;
   cancelText?: string;
-  loading?: boolean;
+  variant?: "default" | "danger";
   onConfirm: () => void;
-  onCancel: () => void;
+  onClose: () => void;
 };
 
 export default function ConfirmDialog({
   open,
   title = "Confirm action",
-  message = "Are you sure you want to continue?",
+  message = "Are you sure?",
   confirmText = "Confirm",
   cancelText = "Cancel",
-  loading = false,
+  variant = "default",
   onConfirm,
-  onCancel,
-}: Props) {
+  onClose,
+}: ConfirmDialogProps) {
+  // Close on ESC
+  useEffect(() => {
+    if (!open) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, onClose]);
+
   if (!open) return null;
 
-  return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-label={title}
-      style={{
-        position: "fixed",
-        inset: 0,
-        display: "grid",
-        placeItems: "center",
-        background: "rgba(0,0,0,0.35)",
-        padding: 16,
-        zIndex: 50,
-      }}
-    >
-      <div
-        style={{
-          background: "#fff",
-          padding: 16,
-          borderRadius: 12,
-          width: "100%",
-          maxWidth: 420,
-        }}
-      >
-        <h3 style={{ marginTop: 0 }}>{title}</h3>
-        <p style={{ marginBottom: 0 }}>{message}</p>
+  const danger = variant === "danger";
 
+  return createPortal(
+    <div className="fixed inset-0 z-[1000]">
+      {/* Overlay */}
+      <div
+        className=" absolute inset-0 bg-black/30 backdrop-blur-xs transition-opacity"
+        onClick={onClose}
+      />
+
+      {/* Modal wrapper */}
+      <div className="absolute inset-0 flex items-center justify-center p-4">
         <div
-          style={{
-            display: "flex",
-            justifyContent: "flex-end",
-            gap: 8,
-            marginTop: 16,
-          }}
+          className=" w-full max-w-md rounded-2xl border border-gray-800 bg-gradient-to-br from-gray-900 to-gray-950 p-6 shadow-2xl animate-in fade-in zoom-in-95 duration-200"
+          role="dialog"
+          aria-modal="true"
         >
-          <button type="button" onClick={onCancel} disabled={loading}>
-            {cancelText}
-          </button>
-          <button type="button" onClick={onConfirm} disabled={loading}>
-            {loading ? "Please wait..." : confirmText}
-          </button>
+          {/* Header */}
+          <div className="flex items-start gap-3">
+            <div
+              className={[
+                "mt-0.5 rounded-xl p-2",
+                danger ? "bg-red-500/10 text-red-400": "bg-cyan-500/10 text-cyan-400",
+              ].join(" ")}
+            >
+              {danger ? (
+                <LogOut className="w-5 h-5" />
+              ) : (
+                <AlertTriangle className="w-5 h-5" />
+              )}
+            </div>
+
+            <div>
+              <h3 className="text-white font-semibold text-lg">{title}</h3>
+              <p className="mt-1 text-sm text-gray-300">{message}</p>
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div className="mt-6 flex justify-end gap-2">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 rounded-xl border border-gray-800 bg-gray-900/40 hover:bg-gray-900/70 text-gray-200 transition"
+              type="button"
+            >
+              {cancelText}
+            </button>
+
+            <button
+              onClick={() => {
+                onConfirm();
+                onClose();
+              }}
+              className={[
+                "px-4 py-2 rounded-xl font-medium transition",
+                danger ? "border border-red-500/30 bg-red-500/15 hover:bg-red-500/25 text-red-200" : "border border-cyan-500/30 bg-cyan-500/15 hover:bg-cyan-500/25 text-white",
+              ].join(" ")}
+              type="button"
+            >
+              {confirmText}
+            </button>
+          </div>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/frontend-web/src/components/common/ConfirmDialog.tsx
+++ b/frontend-web/src/components/common/ConfirmDialog.tsx
@@ -79,7 +79,7 @@ export default function ConfirmDialog({
           <div className="mt-6 flex justify-end gap-2">
             <button
               onClick={onClose}
-              className="px-4 py-2 rounded-xl border border-gray-800 bg-gray-900/40 hover:bg-gray-900/70 text-gray-200 transition"
+              className="px-4 py-2 rounded-xl border border-gray-800 bg-gray-900/40 hover:bg-gray-800/70 text-gray-200 transition cursor-pointer"
               type="button"
             >
               {cancelText}
@@ -91,7 +91,7 @@ export default function ConfirmDialog({
                 onClose();
               }}
               className={[
-                "px-4 py-2 rounded-xl font-medium transition",
+                "px-4 py-2 rounded-xl font-medium transition cursor-pointer",
                 danger ? "border border-red-500/30 bg-red-500/15 hover:bg-red-500/25 text-red-200" : "border border-cyan-500/30 bg-cyan-500/15 hover:bg-cyan-500/25 text-white",
               ].join(" ")}
               type="button"

--- a/frontend-web/src/components/common/Sidebar.tsx
+++ b/frontend-web/src/components/common/Sidebar.tsx
@@ -1,0 +1,109 @@
+import { useMemo } from "react";
+import { NavLink } from "react-router-dom";
+import { LayoutDashboard, GitBranch, Layers3, Users, Star, Ticket, BarChart3, Settings } from "lucide-react";
+
+export type NavItem = {
+  label: string;
+  to: string;
+  icon: React.ReactNode;
+};
+
+type SidebarProps = {
+  collapsed: boolean;
+  onToggleCollapse: () => void;
+  onNavigate?: () => void; 
+};
+
+export default function Sidebar({ collapsed, onNavigate }: SidebarProps) {
+  const navItems = useMemo<NavItem[]>(
+    () => [
+      { label: "Dashboard", to: "/admin", icon: <LayoutDashboard className="w-5 h-5" /> },
+      { label: "Branches", to: "/admin/branches", icon: <GitBranch className="w-5 h-5" /> },
+      { label: "Counters", to: "/admin/counters", icon: <Layers3 className="w-5 h-5" /> },
+      { label: "Queues", to: "/admin/queues", icon: <Ticket className="w-5 h-5" /> },
+      { label: "Tokens", to: "/admin/tokens", icon: <Ticket className="w-5 h-5" /> },
+      { label: "Ratings", to: "/admin/ratings", icon: <Star className="w-5 h-5" /> },
+      { label: "Analytics", to: "/admin/analytics", icon: <BarChart3 className="w-5 h-5" /> },
+      { label: "Users", to: "/admin/users", icon: <Users className="w-5 h-5" /> },
+      { label: "Settings", to: "/admin/settings", icon: <Settings className="w-5 h-5" /> },
+    ],
+    []
+  );
+
+  return (
+    <aside
+      className={[
+        "h-full",
+        "backdrop-blur-xl bg-gradient-to-b from-gray-900/70 to-gray-950/60",
+        "border-r border-gray-800/70",
+        "shadow-2xl",
+        collapsed ? "w-[84px]" : "w-[200px]",
+        "transition-all duration-300 ease-in-out",
+      ].join(" ")}
+    >
+      {/* Brand */}
+      <div className="h-16 px-4 flex items-center justify-between border-b border-gray-800/60">
+        <div className="flex items-center gap-3 overflow-hidden w-full">
+          {/* Logo */}
+          <div className="relative shrink-0">
+            <div className="absolute inset-0 bg-gradient-to-r from-cyan-500 to-blue-500 rounded-xl blur-lg opacity-60" />
+            <div className="relative bg-gradient-to-br from-gray-900 to-gray-800 p-2 rounded-xl border border-gray-700">
+              <span className="text-cyan-400 font-bold">
+                <img src="/icon.svg" alt="Logo" className="w-6 h-6" />
+              </span>
+            </div>
+          </div>
+
+          {/* Brand Text */}
+          <div 
+            className={[
+              "leading-tight transition-all duration-300 ease-in-out",
+              "overflow-hidden", 
+              collapsed 
+                ? "w-0 opacity-0 -translate-x-4" 
+                : "w-auto opacity-100 translate-x-0"
+            ].join(" ")}
+          >
+            <div className="whitespace-nowrap">
+              <div className="text-white font-semibold">ZeroQ</div>
+              <div className="text-xs text-gray-400">Admin Console</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Nav */}
+      <nav className="p-3 space-y-2">
+        {navItems.map((item) => (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            onClick={onNavigate}
+            className={({ isActive }) =>
+              [
+                "group flex items-center gap-3 rounded-xl px-3 py-3",
+                "transition-all duration-200 ease-in-out",
+                isActive
+                  ? "bg-gradient-to-r from-cyan-500/15 to-blue-500/10 border border-cyan-500/20"
+                  : "hover:bg-gray-900/40 border border-transparent",
+              ].join(" ")
+            }
+          >
+            <div className="relative">
+              <div className="absolute -inset-1 rounded-xl blur opacity-0 group-hover:opacity-30 transition bg-gradient-to-r from-cyan-500 to-blue-500" />
+              <div className="relative text-gray-300 group-hover:text-white transition">
+                {item.icon}
+              </div>
+            </div>
+
+            {!collapsed && (
+              <div className="flex-1 text-sm text-gray-300 group-hover:text-white transition">
+                {item.label}
+              </div>
+            )}
+          </NavLink>
+        ))}
+      </nav>
+    </aside>
+  );
+}

--- a/frontend-web/src/components/common/TopBar.tsx
+++ b/frontend-web/src/components/common/TopBar.tsx
@@ -42,7 +42,7 @@ export default function TopBar({
       <div className="flex items-center gap-3">
         {/* Mobile Toggle Button */}
         <button
-          className="md:hidden relative p-2 overflow-hidden rounded-xl border border-gray-800 bg-gray-900/40 hover:bg-gray-900/70 transition-all duration-200 hover:border-cyan-500/30 hover:shadow-[0_0_20px_rgba(34,211,238,0.1)] active:scale-95"
+          className="md:hidden relative p-2 overflow-hidden rounded-xl border border-gray-800 bg-gray-900/40 hover:bg-gray-900/70 transition-all duration-200 hover:border-cyan-500/30 hover:shadow-[0_0_20px_rgba(34,211,238,0.1)] active:scale-95 cursor-pointer"
           onClick={onOpenMobileSidebar}
           aria-label="Open sidebar"
         >
@@ -61,7 +61,7 @@ export default function TopBar({
 
         {/* Desktop Toggle Button */}
         <button
-          className="hidden md:inline-flex relative p-2.5 overflow-hidden rounded-xl border border-gray-800 bg-gray-900/40 hover:bg-gray-900/70 transition-all duration-200 group hover:border-cyan-500/30 hover:shadow-[0_0_20px_rgba(34,211,238,0.1)] active:scale-95"
+          className="hidden md:inline-flex relative p-2.5 overflow-hidden rounded-xl border border-gray-800 bg-gray-900/40 hover:bg-gray-900/70 transition-all duration-200 group hover:border-cyan-500/30 hover:shadow-[0_0_20px_rgba(34,211,238,0.1)] active:scale-95 cursor-pointer"
           onClick={onToggleCollapse}
           aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
           type="button"
@@ -130,31 +130,37 @@ export default function TopBar({
       {/* Right */}
       <div className="flex items-center gap-2">
         <button
-          className="p-2 rounded-xl border border-gray-800 bg-gray-900/40 hover:bg-gray-900/70 transition-all duration-200 group hover:border-cyan-500/30 hover:shadow-[0_0_20px_rgba(34,211,238,0.1)] active:scale-95 relative"
+          className="p-2 rounded-xl border border-gray-800 bg-gray-900/40 hover:bg-gray-900/70 transition-all duration-200 group hover:border-cyan-500/30 hover:shadow-[0_0_20px_rgba(34,211,238,0.1)] active:scale-95 relative cursor-pointer"
           aria-label="Notifications"
         >
           <Bell className="w-5 h-5 text-gray-200" />
           <span className="absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full bg-cyan-400 shadow-[0_0_12px_rgba(34,211,238,0.8)]" />
         </button>
-
-        <div className="hidden sm:flex items-center gap-2 pl-2">
-          <div className="group flex items-center gap-2 p-2 rounded-xl border border-gray-800 bg-gray-900/40 transition-all duration-200 hover:bg-gray-900/70 hover:border-cyan-500/30 hover:shadow-[0_0_18px_rgba(34,211,238,0.15)]">
-            <UserCircle2 className="w-5 h-5 text-gray-200 transition group-hover:text-cyan-300" />    
-            <div className="leading-tight">
-              <div className="text-sm text-white font-medium">
-                {user?.name ?? "Admin"}
-              </div>
-              <div className="text-xs text-gray-400 transition group-hover:text-gray-300">
-                {user?.email ?? "admin@zeroq.com"}
+        <button
+          onClick={() => navigate("/admin/profile")}
+          role="button"
+          tabIndex={0}
+          className="cursor-pointer"
+        >
+          <div className="hidden sm:flex items-center gap-2 pl-2">
+            <div className="group flex items-center gap-2 p-2 rounded-xl border border-gray-800 bg-gray-900/40 transition-all duration-200 hover:bg-gray-900/70 hover:border-cyan-500/30 hover:shadow-[0_0_18px_rgba(34,211,238,0.15)]">
+              <UserCircle2 className="w-5 h-5 text-gray-200 transition group-hover:text-cyan-300" />    
+              <div className="leading-tight">
+                <div className="text-sm text-white font-medium">
+                  {user?.name ?? "Admin"}
+                </div>
+                <div className="text-xs text-gray-400 transition group-hover:text-gray-300">
+                  {user?.email ?? "admin@zeroq.com"}
+                </div>
               </div>
             </div>
           </div>
-        </div>
+        </button>
         <button
           onClick={() => setConfirmOpen(true)}
           aria-label="Logout"
           type="button"
-          className="group p-2 rounded-xl border border-gray-800 bg-gray-900/40 transition-all duration-200 hover:bg-red-500/10 hover:border-red-500/30 hover:shadow-[0_0_18px_rgba(239,68,68,0.2)] active:scale-95"
+          className="group p-2 rounded-xl border border-gray-800 bg-gray-900/40 transition-all duration-200 hover:bg-red-500/10 hover:border-red-500/30 hover:shadow-[0_0_18px_rgba(239,68,68,0.2)] active:scale-95 cursor-pointer"
         >
           <LogOut className="w-5 h-5 text-gray-200 transition group-hover:text-red-400" />
         </button>
@@ -170,7 +176,7 @@ export default function TopBar({
         onClose={() => setConfirmOpen(false)}
         onConfirm={handleLogoutConfirmed}
       />
-      
+
     </header>
   );
 }

--- a/frontend-web/src/components/common/TopBar.tsx
+++ b/frontend-web/src/components/common/TopBar.tsx
@@ -1,0 +1,176 @@
+import { useNavigate } from "react-router-dom";
+import { useState } from "react";
+import ConfirmDialog from "./ConfirmDialog";
+import { useAppDispatch, useAppSelector } from "../../store/hooks";
+import { logout } from "../../store/slices/auth.slice";
+import { selectAuthUser } from "../../store/selectors/auth.selectors";
+import { Menu, X, Bell, Search, Shield, LogOut, UserCircle2 } from "lucide-react";
+
+type TopBarProps = {
+  onOpenMobileSidebar: () => void;
+  title?: string;
+  subtitle?: string;
+  onLogout?: () => void;
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
+};
+
+export default function TopBar({
+  onOpenMobileSidebar,
+  title = "Admin",
+  subtitle = "",
+  onLogout,
+  collapsed = false,
+  onToggleCollapse,
+  }: TopBarProps) {
+
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+  const user = useAppSelector(selectAuthUser);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const handleLogoutConfirmed = () => {
+    dispatch(logout());
+    onLogout?.();
+    navigate("/login", { replace: true });
+  };
+
+  return (
+    <header className="h-16 flex items-center justify-between px-4 md:px-6 border-b border-gray-800/60 backdrop-blur-xl bg-gradient-to-r from-gray-900/55 to-gray-950/40">
+
+      {/* Left */}
+      <div className="flex items-center gap-3">
+        {/* Mobile Toggle Button */}
+        <button
+          className="md:hidden relative p-2 overflow-hidden rounded-xl border border-gray-800 bg-gray-900/40 hover:bg-gray-900/70 transition-all duration-200 hover:border-cyan-500/30 hover:shadow-[0_0_20px_rgba(34,211,238,0.1)] active:scale-95"
+          onClick={onOpenMobileSidebar}
+          aria-label="Open sidebar"
+        >
+          <div className="relative w-5 h-5">
+            <Menu
+              className={[
+                "absolute inset-0 w-5 h-5 text-gray-200",
+                "transition-all duration-800 ease-in-out",
+                collapsed 
+                  ? "opacity-0 rotate-90 scale-0" 
+                  : "opacity-100 rotate-0 scale-100",
+              ].join(" ")}
+            />
+          </div>
+        </button>
+
+        {/* Desktop Toggle Button */}
+        <button
+          className="hidden md:inline-flex relative p-2.5 overflow-hidden rounded-xl border border-gray-800 bg-gray-900/40 hover:bg-gray-900/70 transition-all duration-200 group hover:border-cyan-500/30 hover:shadow-[0_0_20px_rgba(34,211,238,0.1)] active:scale-95"
+          onClick={onToggleCollapse}
+          aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+          type="button"
+        >
+          {/* Hover effect background */}
+          <div className="absolute inset-0 rounded-xl bg-gradient-to-r from-cyan-500/0 via-cyan-500/0 to-cyan-500/0 group-hover:from-cyan-500/5 group-hover:via-cyan-500/10 group-hover:to-cyan-500/5 transition-all duration-300" />
+          
+          <div className="relative w-5 h-5">
+            <Menu
+              className={[
+                "absolute inset-0 w-5 h-5 text-gray-200",
+                "transition-all duration-800 ease-in-out",
+                collapsed 
+                  ? "opacity-100 rotate-0 scale-100" 
+                  : "opacity-0 -rotate-90 scale-0",
+              ].join(" ")}
+            />
+            <X
+              className={[
+                "absolute inset-0 w-5 h-5 text-gray-200",
+                "transition-all duration-800 ease-in-out",
+                collapsed 
+                  ? "opacity-0 rotate-90 scale-0" 
+                  : "opacity-100 rotate-0 scale-100",
+              ].join(" ")}
+            />
+            
+            {/* Subtle pulse effect for collapsed state */}
+            {collapsed && (
+              <div className="absolute -inset-0.5 rounded-full bg-cyan-400/10 blur-sm animate-pulse" />
+            )}
+          </div>
+          
+          {/* Tooltip on hover */}
+          <div className="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 bg-gray-900 border border-gray-800 rounded-lg text-xs text-gray-300 whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
+            {collapsed ? "Expand sidebar" : "Collapse sidebar"}
+          </div>
+        </button>
+
+        <div className="leading-tight">
+          <div className="flex items-center gap-2">
+            <Shield className="w-4 h-4 text-cyan-400" />
+            <h1 className="text-white font-semibold">{title}</h1>
+          </div>
+          <p className="text-xs text-gray-400">{subtitle}</p>
+        </div>
+      </div>
+
+      {/* Center */}
+      <div className="hidden lg:flex items-center w-[520px]">
+        <div className="relative w-full group">
+          <div className="absolute -inset-0.5 bg-gradient-to-r from-cyan-500 to-blue-500 rounded-xl blur opacity-0 group-hover:opacity-25 transition duration-300" />
+          <div className="relative flex items-center gap-2 bg-gray-900/40 border border-gray-800 rounded-xl px-3 py-2">
+            <Search className="w-4 h-4 text-gray-400" />
+            <input
+              className="w-full bg-transparent outline-none text-sm text-gray-200 placeholder:text-gray-500"
+              placeholder="Search branches, queues, tokens..."
+            />
+            <span className="text-[10px] text-gray-500 border border-gray-700 rounded px-2 py-0.5">
+              Search
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Right */}
+      <div className="flex items-center gap-2">
+        <button
+          className="p-2 rounded-xl border border-gray-800 bg-gray-900/40 hover:bg-gray-900/70 transition-all duration-200 group hover:border-cyan-500/30 hover:shadow-[0_0_20px_rgba(34,211,238,0.1)] active:scale-95 relative"
+          aria-label="Notifications"
+        >
+          <Bell className="w-5 h-5 text-gray-200" />
+          <span className="absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full bg-cyan-400 shadow-[0_0_12px_rgba(34,211,238,0.8)]" />
+        </button>
+
+        <div className="hidden sm:flex items-center gap-2 pl-2">
+          <div className="group flex items-center gap-2 p-2 rounded-xl border border-gray-800 bg-gray-900/40 transition-all duration-200 hover:bg-gray-900/70 hover:border-cyan-500/30 hover:shadow-[0_0_18px_rgba(34,211,238,0.15)]">
+            <UserCircle2 className="w-5 h-5 text-gray-200 transition group-hover:text-cyan-300" />    
+            <div className="leading-tight">
+              <div className="text-sm text-white font-medium">
+                {user?.name ?? "Admin"}
+              </div>
+              <div className="text-xs text-gray-400 transition group-hover:text-gray-300">
+                {user?.email ?? "admin@zeroq.com"}
+              </div>
+            </div>
+          </div>
+        </div>
+        <button
+          onClick={() => setConfirmOpen(true)}
+          aria-label="Logout"
+          type="button"
+          className="group p-2 rounded-xl border border-gray-800 bg-gray-900/40 transition-all duration-200 hover:bg-red-500/10 hover:border-red-500/30 hover:shadow-[0_0_18px_rgba(239,68,68,0.2)] active:scale-95"
+        >
+          <LogOut className="w-5 h-5 text-gray-200 transition group-hover:text-red-400" />
+        </button>
+      </div>
+
+      <ConfirmDialog
+        open={confirmOpen}
+        variant="danger"
+        title="Logout?"
+        message="Are you sure you want to logout from ZeroQ Admin Console?"
+        confirmText="Logout"
+        cancelText="Cancel"
+        onClose={() => setConfirmOpen(false)}
+        onConfirm={handleLogoutConfirmed}
+      />
+      
+    </header>
+  );
+}

--- a/frontend-web/src/layouts/AdminLayout.tsx
+++ b/frontend-web/src/layouts/AdminLayout.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import { Outlet } from "react-router-dom";
+import Sidebar from "../components/common/Sidebar";
+import TopBar from "../components/common/TopBar";
+
+export default function AdminLayout() {
+  const [collapsed, setCollapsed] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const closeMobile = () => setMobileOpen(false);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-black">
+      {/* Mobile overlay */}
+      {mobileOpen && (
+        <button
+          className="fixed inset-0 bg-black/60 z-40 md:hidden"
+          onClick={closeMobile}
+          aria-label="Close sidebar overlay"
+        />
+      )}
+
+      <div className="flex min-h-screen">
+        {/* Sidebar (desktop) */}
+        <div className="hidden md:block">
+          <Sidebar
+            collapsed={collapsed}
+            onToggleCollapse={() => setCollapsed((v) => !v)}
+          />
+        </div>
+
+        {/* Sidebar (mobile drawer) */}
+        <div
+          className={[
+            "fixed z-50 inset-y-0 left-0 md:hidden",
+            "transition-transform duration-300",
+            mobileOpen ? "translate-x-0" : "-translate-x-full",
+          ].join(" ")}
+        >
+          <Sidebar
+            collapsed={false}
+            onToggleCollapse={() => {}}
+            onNavigate={closeMobile}
+          />
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 flex flex-col">
+          <TopBar
+            onOpenMobileSidebar={() => setMobileOpen(true)}
+            title="Admin Portal"
+            collapsed={collapsed}
+            onToggleCollapse={() => setCollapsed((v) => !v)}
+          />
+
+          <main className="flex-1 p-4 md:p-6">
+            <div className="rounded-2xl border border-gray-800/70 bg-gradient-to-br from-gray-900/40 to-gray-950/20 backdrop-blur-xl shadow-2xl min-h-[calc(100vh-8rem)] p-4 md:p-6">
+              <Outlet />
+            </div>
+          </main>
+
+          <footer className="px-4 md:px-6 py-4 text-center text-xs text-gray-500 border-t border-gray-800/60">
+            © 2025 ZeroQ • Audit logging enabled • Secure Admin Console
+          </footer>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend-web/src/store/selectors/auth.selectors.ts
+++ b/frontend-web/src/store/selectors/auth.selectors.ts
@@ -1,0 +1,3 @@
+import type { RootState } from "../store";
+
+export const selectAuthUser = (state: RootState) => state.auth.user;


### PR DESCRIPTION
## Summary
Introduce a unified **Admin Layout** for the ZeroQ frontend that provides a consistent navigation shell across all admin-facing pages.  
This layout integrates a **Sidebar** and **Topbar**, while preserving the existing authentication and role-based access control flow.

Closes #47 .

---

## Changes
- Added reusable `AdminLayout` with `<Outlet />` support for nested routing
- Implemented **Sidebar** with:
  - Admin module navigation links
  - Collapsible behavior on desktop
  - Drawer behavior on mobile
  - Active route highlighting
- Implemented **Topbar** with:
  - Page title & subtitle
  - Search input (UI only)
  - Notifications indicator
  - User profile section with profile navigation
  - Logout action with confirmation dialog
- Integrated `AdminLayout` under `ProtectedRoute` and `RoleRoute`
- Reorganized admin routes under the shared layout for improved scalability
- Ensured layout follows ZeroQ’s dark-neon design system

---

## Acceptance Criteria
- Admin pages render inside a shared layout with sidebar & topbar
- Sidebar highlights active routes correctly
- Layout is fully responsive (desktop & mobile)
- Unauthorized users are blocked via existing RBAC logic
- No regression in authentication or routing behavior

---

## Verification
- `npm install`
- `npm run dev`
- Navigate to `/admin/*` routes
- Resize viewport to verify responsive sidebar behavior
- Verify profile navigation and logout flow

---

## Notes
- No backend changes required
- RBAC and authentication logic reused as-is
- Layout is designed to be easily extendable for future admin modules
