### PR TITLE
feat(profile): add profile page with typed API integration

### DIFF
--- a/backend/src/modules/user/controller.js
+++ b/backend/src/modules/user/controller.js
@@ -91,3 +91,12 @@ export const resetUserPassword = asyncHandler(async (req, res) => {
 
   return new ApiResponse(200, 'Password reset successfully', null).send(res);
 });
+
+export const changeMyPassword = asyncHandler(async (req, res) => {
+  const userId = req.user.id;
+  const { currentPassword, newPassword } = req.body;
+
+  await userService.changeOwnPassword(userId, currentPassword, newPassword);
+
+  return new ApiResponse(200, 'Password updated successfully', null).send(res);
+});

--- a/backend/src/modules/user/routes.js
+++ b/backend/src/modules/user/routes.js
@@ -7,6 +7,7 @@ import {
   validateUpdateOwnProfile,
   validateStatusUpdate,
   validateResetPassword,
+  validateChangeOwnPassword,
 } from './validation.js';
 import {
   getUsers,
@@ -18,6 +19,7 @@ import {
   updateMe,
   updateUserStatus,
   resetUserPassword,
+  changeMyPassword,
 } from './controller.js';
 import { ROLES } from '../../core/constants.js';
 
@@ -27,6 +29,7 @@ router.use(auth);
 
 router.get('/me', getMe);
 router.patch('/me', validateUpdateOwnProfile, updateMe);
+router.patch('/me/password', validateChangeOwnPassword, changeMyPassword);
 
 router.get('/', allowRoles(ROLES.ADMIN), getUsers);
 router.get('/staff', allowRoles(ROLES.ADMIN), getStaff);

--- a/backend/src/modules/user/service.js
+++ b/backend/src/modules/user/service.js
@@ -1,7 +1,7 @@
 import ApiError from '../../core/apiError.js';
 import User from '../../database/models/User.js';
 import Branch from '../../database/models/Branch.js';
-import { hashPassword } from '../../utils/password.js';
+import { hashPassword, comparePassword } from '../../utils/password.js';
 import { ROLES } from '../../core/constants.js';
 
 const ROLE_VALUES = Object.values(ROLES);
@@ -214,6 +214,19 @@ export const resetUserPassword = async (userId, newPassword) => {
   if (!user) {
     throw new ApiError(404, 'User not found');
   }
+
+  return true;
+};
+
+export const changeOwnPassword = async (userId, currentPassword, newPassword) => {
+  const user = await User.findById(userId);
+  if (!user) throw new ApiError(404, 'User not found');
+
+  const ok = await comparePassword(currentPassword, user.password);
+  if (!ok) throw new ApiError(400, 'Current password is incorrect');
+
+  user.password = await hashPassword(newPassword);
+  await user.save();
 
   return true;
 };

--- a/backend/src/modules/user/validation.js
+++ b/backend/src/modules/user/validation.js
@@ -180,3 +180,21 @@ export const validateResetPassword = (req, res, next) => {
 
   next();
 };
+
+export const validateChangeOwnPassword = (req, res, next) => {
+  const { currentPassword, newPassword } = req.body;
+
+  if (!currentPassword || typeof currentPassword !== "string") {
+    return res.status(400).json({ success: false, message: "Current password is required" });
+  }
+
+  if (!newPassword || !isStrongPassword(newPassword)) {
+    return res.status(400).json({
+      success: false,
+      message:
+        "New password must be at least 8 chars and include uppercase, lowercase, number, and special character",
+    });
+  }
+
+  next();
+};

--- a/frontend-web/src/app/routes/index.tsx
+++ b/frontend-web/src/app/routes/index.tsx
@@ -7,6 +7,7 @@ import ProtectedRoute from "./ProtectedRoute";
 import RoleRoute from "./RoleRoute";
 import { ADMIN_PORTAL_ROLES } from "../../types/enums";
 import AdminLayout from "../../layouts/AdminLayout";
+import ProfilePage from "../../features/profile/pages/ProfilePage";
 
 export const router = createBrowserRouter([
   { path: "/login", element: <LoginPage /> },
@@ -15,13 +16,15 @@ export const router = createBrowserRouter([
   {
     element: <ProtectedRoute />,
     children: [
-      {
+      { 
+        path: "/admin",
         element: <AdminLayout />,
         children: [
           {
             element: <RoleRoute allowed={ADMIN_PORTAL_ROLES} />,
             children: [
-              { path: "/", element: <HomePage /> },
+              { index: true, element: <HomePage /> },
+              { path: "profile", element: <ProfilePage /> },
             ],
           },
         ],

--- a/frontend-web/src/components/common/Sidebar.tsx
+++ b/frontend-web/src/components/common/Sidebar.tsx
@@ -25,7 +25,7 @@ export default function Sidebar({ collapsed, onNavigate }: SidebarProps) {
       { label: "Ratings", to: "/admin/ratings", icon: <Star className="w-5 h-5" /> },
       { label: "Analytics", to: "/admin/analytics", icon: <BarChart3 className="w-5 h-5" /> },
       { label: "Users", to: "/admin/users", icon: <Users className="w-5 h-5" /> },
-      { label: "Settings", to: "/admin/settings", icon: <Settings className="w-5 h-5" /> },
+      { label: "Settings", to: "/admin/profile", icon: <Settings className="w-5 h-5" /> },
     ],
     []
   );

--- a/frontend-web/src/features/auth/hooks/useLogin.ts
+++ b/frontend-web/src/features/auth/hooks/useLogin.ts
@@ -38,7 +38,7 @@ export function useLogin() {
         })
       );
 
-      navigate("/", { replace: true });
+      navigate("/admin", { replace: true });
       return true;
     } catch (e) {
       const message = e instanceof Error ? e.message : "Login failed";

--- a/frontend-web/src/features/profile/api/me.api.ts
+++ b/frontend-web/src/features/profile/api/me.api.ts
@@ -1,0 +1,30 @@
+import { apiFetch } from "../../../services/http/interceptors";
+import type { ApiResponse, MeDto } from "../types";
+import { PROFILE_ENDPOINTS } from "./profile.endpoints";
+
+export function getMe(): Promise<MeDto> {
+  return apiFetch<MeDto>(PROFILE_ENDPOINTS.me, { 
+    method: "GET" 
+  });
+}
+
+export function updateMe(payload: {
+  name: string;
+  email: string;
+  telephone: string;
+}): Promise<MeDto> {
+  return apiFetch<MeDto>(PROFILE_ENDPOINTS.me, {
+    method: "PATCH",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function changeMyPassword(payload: {
+  currentPassword: string;
+  newPassword: string;
+}) {
+  return apiFetch<ApiResponse<null>>(PROFILE_ENDPOINTS.changePassword, {
+    method: "PATCH",
+    body: JSON.stringify(payload),
+  });
+}

--- a/frontend-web/src/features/profile/api/profile.endpoints.ts
+++ b/frontend-web/src/features/profile/api/profile.endpoints.ts
@@ -1,0 +1,4 @@
+export const PROFILE_ENDPOINTS = {
+  me: "/users/me",
+  changePassword: "/users/me/password",
+} as const;

--- a/frontend-web/src/features/profile/components/SecurityCard.tsx
+++ b/frontend-web/src/features/profile/components/SecurityCard.tsx
@@ -1,0 +1,194 @@
+import { useMemo, useState } from "react";
+import { Shield, Eye, EyeOff, Loader2, Lock } from "lucide-react";
+import toast from "react-hot-toast";
+import { changeMyPassword } from "../api/me.api";
+
+const strongPassword = new RegExp(
+  "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_\\-+=\\[\\]{};':\"\\\\|,.<>/?]).{8,}$"
+);
+
+function getErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return "Password update failed";
+}
+
+export default function SecurityCard() {
+  const [showCurrent, setShowCurrent] = useState(false);
+  const [showNew, setShowNew] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const [saving, setSaving] = useState(false);
+
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+
+  const error = useMemo(() => {
+    if (!currentPassword && !newPassword && !confirmPassword) return null;
+    if (!currentPassword) return "Current password is required";
+    if (!newPassword) return "New password is required";
+    if (!strongPassword.test(newPassword))
+      return "New password must be 8+ chars with uppercase, lowercase, number & special character";
+    if (newPassword !== confirmPassword) return "Passwords do not match";
+    return null;
+  }, [currentPassword, newPassword, confirmPassword]);
+
+  const canSubmit =
+    !saving && !error && currentPassword && newPassword && confirmPassword;
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+
+    setSaving(true);
+    try {
+      await changeMyPassword({ currentPassword, newPassword });
+      toast.success("Password updated successfully");
+
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+    } catch (err: unknown) {
+      toast.error(getErrorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="backdrop-blur-xl bg-gradient-to-br from-gray-800/40 to-gray-900/40 rounded-2xl border border-gray-700/50 shadow-2xl overflow-hidden">
+      <div className="h-1 bg-gradient-to-r from-cyan-500 via-blue-500 to-purple-500"></div>
+
+      <div className="p-8">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="relative">
+            <div className="absolute inset-0 bg-gradient-to-r from-cyan-500 to-blue-500 rounded-full blur-md opacity-50"></div>
+            <div className="relative bg-gradient-to-br from-gray-800 to-gray-900 p-3 rounded-full border border-cyan-500/30">
+              <Shield className="w-6 h-6 text-cyan-400" />
+            </div>
+          </div>
+
+          <div>
+            <h3 className="text-xl font-bold text-white">Security</h3>
+            <p className="text-sm text-gray-400">Change your password</p>
+          </div>
+        </div>
+
+        <form onSubmit={onSubmit} className="space-y-5">
+          {/* Current */}
+          <div>
+            <label className="text-sm text-gray-300">Current Password</label>
+            <div className="mt-2 flex items-center gap-2 rounded-xl border border-gray-700/60 bg-gray-900/40 px-4 py-3">
+              <Lock className="w-5 h-5 text-gray-400" />
+              <input
+                type={showCurrent ? "text" : "password"}
+                value={currentPassword}
+                onChange={(e) => setCurrentPassword(e.target.value)}
+                className="w-full bg-transparent outline-none text-white placeholder:text-gray-500"
+                placeholder="••••••••"
+              />
+              <button
+                type="button"
+                onClick={() => setShowCurrent((s) => !s)}
+                className="text-gray-400 hover:text-gray-200"
+                aria-label={showCurrent ? "Hide password" : "Show password"}
+              >
+                {showCurrent ? (
+                  <EyeOff className="w-5 h-5" />
+                ) : (
+                  <Eye className="w-5 h-5" />
+                )}
+              </button>
+            </div>
+          </div>
+
+          {/* New */}
+          <div>
+            <label className="text-sm text-gray-300">New Password</label>
+            <div className="mt-2 flex items-center gap-2 rounded-xl border border-gray-700/60 bg-gray-900/40 px-4 py-3">
+              <Shield className="w-5 h-5 text-gray-400" />
+              <input
+                type={showNew ? "text" : "password"}
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                className="w-full bg-transparent outline-none text-white placeholder:text-gray-500"
+                placeholder="Min 8 chars, strong password"
+              />
+              <button
+                type="button"
+                onClick={() => setShowNew((s) => !s)}
+                className="text-gray-400 hover:text-gray-200"
+                aria-label={showNew ? "Hide password" : "Show password"}
+              >
+                {showNew ? (
+                  <EyeOff className="w-5 h-5" />
+                ) : (
+                  <Eye className="w-5 h-5" />
+                )}
+              </button>
+            </div>
+            <p className="text-xs text-gray-500 mt-2">
+              Must include uppercase, lowercase, number & special character.
+            </p>
+          </div>
+
+          {/* Confirm */}
+          <div>
+            <label className="text-sm text-gray-300">Confirm New Password</label>
+            <div className="mt-2 flex items-center gap-2 rounded-xl border border-gray-700/60 bg-gray-900/40 px-4 py-3">
+              <Shield className="w-5 h-5 text-gray-400" />
+              <input
+                type={showConfirm ? "text" : "password"}
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                className="w-full bg-transparent outline-none text-white placeholder:text-gray-500"
+                placeholder="••••••••"
+              />
+              <button
+                type="button"
+                onClick={() => setShowConfirm((s) => !s)}
+                className="text-gray-400 hover:text-gray-200"
+                aria-label={showConfirm ? "Hide password" : "Show password"}
+              >
+                {showConfirm ? (
+                  <EyeOff className="w-5 h-5" />
+                ) : (
+                  <Eye className="w-5 h-5" />
+                )}
+              </button>
+            </div>
+          </div>
+
+          {error && (
+            <div className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+              {error}
+            </div>
+          )}
+
+          <div className="pt-2 flex justify-end">
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="inline-flex items-center gap-2 rounded-xl px-5 py-3 font-semibold text-white
+                         bg-gradient-to-r from-cyan-500 to-blue-500
+                         disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {saving ? (
+                <>
+                  <Loader2 className="w-5 h-5 animate-spin" />
+                  Updating...
+                </>
+              ) : (
+                <>
+                  <Shield className="w-5 h-5" />
+                  Update Password
+                </>
+              )}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend-web/src/features/profile/pages/ProfilePage.tsx
+++ b/frontend-web/src/features/profile/pages/ProfilePage.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useMemo, useState } from "react";
+import { Shield, User, Phone, Mail, Save, Loader2 } from "lucide-react";
+import toast from "react-hot-toast";
+import { getMe, updateMe } from "../api/me.api";
+import { type MeDto } from "../types";
+import SecurityCard from "../components/SecurityCard";
+
+type FormState = { name: string; email: string; telephone: string };
+
+function getErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return "Something went wrong";
+}
+
+export default function ProfilePage() {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [me, setMe] = useState<MeDto | null>(null);
+
+  const [form, setForm] = useState<FormState>({
+    name: "",
+    email: "",
+    telephone: "",
+  });
+
+  const canSave = useMemo(() => {
+    if (!form.name.trim()) return false;
+    if (!form.email.trim()) return false;
+    if (!/^\d{9,15}$/.test(form.telephone.trim())) return false;
+    return true;
+  }, [form]);
+
+  useEffect(() => {
+    let mounted = true;
+
+    (async () => {
+      try {
+        const meData = await getMe();
+        if (!mounted) return;
+        setMe(meData);
+        setForm({
+          name: meData.name ?? "",
+          email: meData.email ?? "",
+          telephone: meData.telephone ?? "",
+        });
+      } catch (err: unknown) {
+        toast.error(getErrorMessage(err) || "Failed to load profile");
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const onChange =
+    (key: keyof FormState) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      setForm((p) => ({ ...p, [key]: e.target.value }));
+    };
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSave || saving) return;
+
+    setSaving(true);
+    try {
+      const updated = await updateMe({
+        name: form.name.trim(),
+        email: form.email.trim(),
+        telephone: form.telephone.trim(),
+      });
+
+      setMe(updated);
+      toast.success("Profile updated");
+      } catch (err: unknown) {
+        toast.error(getErrorMessage(err) || "Update failed");
+      } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+      <div className="relative z-10 min-h-screen flex items-center justify-center p-4">
+        <div className="w-full max-w-xl space-y-6">
+          {/* Header */}
+          <div className="text-center mb-2 animate-fade-in">
+            <div className="flex items-center justify-center gap-3 mb-4">
+              <h1 className="text-3xl font-bold bg-gradient-to-r from-cyan-400 to-blue-400 bg-clip-text text-transparent">
+                Profile Settings
+              </h1>
+            </div>
+          </div>
+
+          {/* Profile Card */}
+          <div className="backdrop-blur-xl bg-gradient-to-br from-gray-800/40 to-gray-900/40 rounded-2xl border border-gray-700/50 shadow-2xl overflow-hidden">
+            <div className="h-1 bg-gradient-to-r from-cyan-500 via-blue-500 to-purple-500"></div>
+
+            <div className="p-8">
+              <div className="flex items-center justify-between gap-4 mb-8">
+                <div className="flex items-center gap-3">
+                  <div className="relative">
+                    <div className="absolute inset-0 bg-gradient-to-r from-cyan-500 to-blue-500 rounded-full blur-md opacity-50"></div>
+                    <div className="relative bg-gradient-to-br from-gray-800 to-gray-900 p-3 rounded-full border border-cyan-500/30">
+                      <User className="w-6 h-6 text-cyan-400" />
+                    </div>
+                  </div>
+                  <div>
+                    <h2 className="text-2xl font-bold text-white">My Profile</h2>
+                    <p className="text-sm text-gray-400">Update your details</p>
+                  </div>
+                </div>
+
+                {me && (
+                  <div className="text-right">
+                    <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-gray-700/60 bg-gray-900/40">
+                      <Shield className="w-4 h-4 text-cyan-400" />
+                      <span className="text-sm text-white">{me.role}</span>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {loading ? (
+                <div className="flex items-center justify-center py-12 text-gray-300">
+                  <Loader2 className="w-5 h-5 animate-spin mr-2" />
+                  Loading profile...
+                </div>
+              ) : (
+                <form onSubmit={onSubmit} className="space-y-5">
+                  <div>
+                    <label className="text-sm text-gray-300">Full Name</label>
+                    <div className="mt-2 flex items-center gap-2 rounded-xl border border-gray-700/60 bg-gray-900/40 px-4 py-3">
+                      <User className="w-5 h-5 text-gray-400" />
+                      <input
+                        value={form.name}
+                        onChange={onChange("name")}
+                        className="w-full bg-transparent outline-none text-white placeholder:text-gray-500"
+                        placeholder="Your name"
+                      />
+                    </div>
+                  </div>
+
+                  <div>
+                    <label className="text-sm text-gray-300">Email</label>
+                    <div className="mt-2 flex items-center gap-2 rounded-xl border border-gray-700/60 bg-gray-900/40 px-4 py-3">
+                      <Mail className="w-5 h-5 text-gray-400" />
+                      <input
+                        value={form.email}
+                        onChange={onChange("email")}
+                        className="w-full bg-transparent outline-none text-white placeholder:text-gray-500"
+                        placeholder="you@company.com"
+                      />
+                    </div>
+                  </div>
+
+                  <div>
+                    <label className="text-sm text-gray-300">Telephone</label>
+                    <div className="mt-2 flex items-center gap-2 rounded-xl border border-gray-700/60 bg-gray-900/40 px-4 py-3">
+                      <Phone className="w-5 h-5 text-gray-400" />
+                      <input
+                        value={form.telephone}
+                        onChange={onChange("telephone")}
+                        className="w-full bg-transparent outline-none text-white placeholder:text-gray-500"
+                        placeholder="07X XXXX XXX"
+                      />
+                    </div>
+                    {!/^\d{9,15}$/.test(form.telephone.trim()) && (
+                      <p className="text-xs text-red-300 mt-2">
+                        Telephone must contain 9–15 digits (numbers only)
+                      </p>
+                    )}
+                  </div>
+
+                  {me && (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 pt-2">
+                      <div className="rounded-xl border border-gray-700/60 bg-gray-900/30 p-4">
+                        <div className="text-xs text-gray-400">Branch</div>
+                        <div className="text-sm text-white mt-1">
+                          {me.branch?.name ?? "Not assigned"}
+                        </div>
+                      </div>
+                      <div className="rounded-xl border border-gray-700/60 bg-gray-900/30 p-4">
+                        <div className="text-xs text-gray-400">Status</div>
+                        <div className="text-sm text-white mt-1">
+                          {me.isActive ? "Active" : "Disabled"}
+                        </div>
+                      </div>
+                    </div>
+                  )}
+
+                  <div className="pt-4 flex items-center justify-end gap-3">
+                    <button
+                      type="submit"
+                      disabled={!canSave || saving}
+                      className="inline-flex items-center gap-2 rounded-xl px-5 py-3 font-semibold text-white
+                                 bg-gradient-to-r from-cyan-500 to-blue-500
+                                 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {saving ? (
+                        <>
+                          <Loader2 className="w-5 h-5 animate-spin" />
+                          Saving...
+                        </>
+                      ) : (
+                        <>
+                          <Save className="w-5 h-5" />
+                          Save Changes
+                        </>
+                      )}
+                    </button>
+                  </div>
+                </form>
+              )}
+
+              <div className="mt-6 pt-6 border-t border-gray-700/50">
+                <div className="flex items-center gap-2 text-sm text-gray-400">
+                  <Shield className="w-4 h-4" />
+                  <span>All actions are logged and monitored</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Password change card */}
+          <SecurityCard />
+        </div>
+      </div>
+  );
+}

--- a/frontend-web/src/features/profile/types.ts
+++ b/frontend-web/src/features/profile/types.ts
@@ -1,0 +1,24 @@
+import type { ROLES } from "../../types/enums";
+
+export type BranchDto = {
+  _id: string;
+  name: string;
+} | null;
+
+export type MeDto = {
+  _id: string;
+  name: string;
+  email: string;
+  telephone: string;
+  role: ROLES;
+  branch: BranchDto;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ApiResponse<T> = {
+  statusCode: number;
+  message: string;
+  data: T;
+};


### PR DESCRIPTION
## Overview
This PR introduces the Profile feature, allowing authenticated users to view and update their personal information with a fully typed and structured API integration.

The implementation follows existing frontend architecture and ensures type safety, consistency, and clean separation of concerns.

Closes #49 .
---

## ✨ What’s Included
- Profile page UI with editable user details
- Typed API helpers for profile actions (`getMe`, `updateMe`)
- Centralized profile endpoints configuration
- Secure password-related endpoint preparation
- Proper loading, saving, and validation states
- Improved type safety (MeDto instead of ApiResponse wrapper)
- Security information section

---

## Technical Details
- Uses `apiFetch` interceptor for authenticated requests
- Removes ambiguous `ApiResponse<T>` usage in favor of DTO-based returns
- Prevents runtime crashes caused by undefined data
- Aligns frontend typing with backend response structure

---

## 🔒 Security Notes
- Profile data is fetched using authenticated endpoints
- No sensitive information is cached on the client
- Password update endpoint prepared for secure handling

---

## 🧪 How to Test
1. Login as an authenticated user
2. Navigate to **Profile Settings**
3. Verify profile details are displayed correctly
4. Update name, email, or telephone
5. Save changes and confirm success toast appears
6. Reload page and ensure updated data persists

---

## ✅ Checklist
- [x] Profile APIs implemented and typed
- [x] Profile page UI completed
- [x] Runtime errors resolved
- [x] TypeScript checks passing
- [x] Manual testing completed
