### PR TITLE
feat(counter): implement counter management module

### DIFF
--- a/backend/src/modules/counter/service.js
+++ b/backend/src/modules/counter/service.js
@@ -24,7 +24,7 @@ export const createCounter = async ({ branchId, name, code, services }) => {
     ...(services ? { services } : {}),
   });
 
-  return counter;
+  return await Counter.findById(counter._id).populate('branch', 'name code');
 };
 
 export const listCounters = async (query = {}) => {
@@ -95,7 +95,7 @@ export const updateCounter = async (id, payload = {}) => {
   }
 
   await counter.save();
-  return counter;
+  return await Counter.findById(counter._id).populate('branch', 'name code');
 };
 
 export const setCounterStatus = async (id, isActive) => {
@@ -104,15 +104,12 @@ export const setCounterStatus = async (id, isActive) => {
 
   counter.isActive = isActive;
   await counter.save();
-  return counter;
+  return await Counter.findById(counter._id).populate('branch', 'name code');
 };
 
-// soft delete
 export const deleteCounter = async (id) => {
-  const counter = await Counter.findById(id);
+  const counter = await Counter.findByIdAndDelete(id);
   if (!counter) throw new ApiError(404, 'Counter not found');
 
-  counter.isActive = false;
-  await counter.save();
   return counter;
 };

--- a/frontend-web/src/app/routes/index.tsx
+++ b/frontend-web/src/app/routes/index.tsx
@@ -9,6 +9,7 @@ import { ADMIN_PORTAL_ROLES } from "../../types/enums";
 import AdminLayout from "../../layouts/AdminLayout";
 import ProfilePage from "../../features/profile/pages/ProfilePage";
 import { BranchListPage, BranchDetailsPage } from "../../features/branch";
+import { CounterPage } from "../../features/counter";
 
 export const router = createBrowserRouter([
   { path: "/", element: <Navigate to="/login" replace /> },
@@ -29,6 +30,7 @@ export const router = createBrowserRouter([
               { path: "profile", element: <ProfilePage /> },
               { path: "branches", element: <BranchListPage /> },
               { path: "branches/:id", element: <BranchDetailsPage /> },
+              { path: "counters", element: <CounterPage /> },
             ],
           },
         ],

--- a/frontend-web/src/features/branch/components/BranchTable.tsx
+++ b/frontend-web/src/features/branch/components/BranchTable.tsx
@@ -46,7 +46,7 @@ export default function BranchTable({
         },
         {
           header: "Actions",
-          className: "w-[180px] text-right",
+          className: "w-[180px] text-center",
           cell: (row: Branch) => (
             <div className="flex items-center justify-end gap-2 whitespace-nowrap">
               <Button

--- a/frontend-web/src/features/counter/api/counter.api.ts
+++ b/frontend-web/src/features/counter/api/counter.api.ts
@@ -1,0 +1,39 @@
+import { apiFetch } from "../../../services/http/interceptors";
+import type {
+  CounterDto,
+  CreateCounterDto,
+  UpdateCounterDto,
+  ChangeCounterStatusDto,
+  PaginatedResult,
+} from "../types";
+import { COUNTER_ENDPOINTS } from "./counter.endpoints";
+
+export const counterApi = {
+  list: async () => {
+    const res = await apiFetch<PaginatedResult<CounterDto>>(COUNTER_ENDPOINTS.list);
+    return res.items;
+  },
+  
+  getById: (id: string) => apiFetch<CounterDto>(COUNTER_ENDPOINTS.byId(id)),
+
+  create: (payload: CreateCounterDto) =>
+    apiFetch<CounterDto>(COUNTER_ENDPOINTS.list, {
+      method: "POST",
+      body: JSON.stringify(payload),
+    }),
+
+  update: (id: string, payload: UpdateCounterDto) =>
+    apiFetch<CounterDto>(COUNTER_ENDPOINTS.update(id), {
+      method: "PATCH",
+      body: JSON.stringify(payload),
+    }),
+
+  changeStatus: (id: string, payload: ChangeCounterStatusDto) =>
+    apiFetch<CounterDto>(COUNTER_ENDPOINTS.changeStatus(id), {
+      method: "PATCH",
+      body: JSON.stringify(payload),
+    }),
+
+  remove: (id: string) =>
+    apiFetch<void>(COUNTER_ENDPOINTS.remove(id), { method: "DELETE" }),
+};

--- a/frontend-web/src/features/counter/api/counter.endpoints.ts
+++ b/frontend-web/src/features/counter/api/counter.endpoints.ts
@@ -1,0 +1,7 @@
+export const COUNTER_ENDPOINTS = {
+  list: "/counters",
+  byId: (id: string) => `/counters/${id}`,
+  update: (id: string) => `/counters/${id}`,
+  changeStatus: (id: string) => `/counters/${id}/status`,
+  remove: (id: string) => `/counters/${id}`,
+};

--- a/frontend-web/src/features/counter/components/CounterForm.tsx
+++ b/frontend-web/src/features/counter/components/CounterForm.tsx
@@ -1,0 +1,164 @@
+import { useMemo, useState } from "react";
+import Input from "../../../components/ui/Input";
+import Button from "../../../components/ui/Button";
+import Select from "../../../components/ui/Select";
+import Badge from "../../../components/ui/Badge";
+
+import type { CounterDto, CounterFormValues } from "../types";
+
+type Props = {
+  initial?: CounterDto | null;
+  branchOptions: { label: string; value: string }[];
+  submitting?: boolean;
+  onCancel: () => void;
+  onSubmit: (values: {
+    branchId: string;
+    name: string;
+    code: string | null;
+    services: string[];
+    isActive: boolean;
+  }) => void;
+};
+
+function toFormValues(c?: CounterDto | null): CounterFormValues {
+  return {
+    branchId: c?.branch._id ?? "",
+    name: c?.name ?? "",
+    code: c?.code ?? "",
+    servicesText: (c?.services ?? []).join(", "),
+    isActive: c?.isActive ?? true,
+  };
+}
+
+function parseServices(text: string): string[] {
+  return text
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export default function CounterForm({
+  initial,
+  branchOptions,
+  submitting = false,
+  onCancel,
+  onSubmit,
+}: Props) {
+  const isEdit = Boolean(initial?._id);
+
+  const [form, setForm] = useState<CounterFormValues>(() => toFormValues(initial));
+
+  const servicesPreview = useMemo(
+    () => parseServices(form.servicesText),
+    [form.servicesText]
+  );
+
+  const canSubmit =
+    form.branchId.trim().length > 0 && form.name.trim().length > 0 && !submitting;
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+
+    const payload = {
+      branchId: form.branchId,
+      name: form.name.trim(),
+      code: form.code.trim() ? form.code.trim() : null,
+      services: servicesPreview,
+      isActive: form.isActive,
+    };
+
+    onSubmit(payload);
+  };
+
+  return (
+    <form key={initial?._id ?? "new"} onSubmit={submit} className="space-y-4">
+      <Select
+        label="Branch"
+        value={form.branchId}
+        disabled={isEdit}
+        onChange={(e) =>
+          setForm((p) => ({ ...p, branchId: e.target.value }))
+        }
+      >
+        <option value="" disabled>
+          Select branch
+        </option>
+        {branchOptions.map((b) => (
+          <option key={b.value} value={b.value}>
+            {b.label}
+          </option>
+        ))}
+      </Select>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <Input
+          label="Counter name"
+          value={form.name}
+          onChange={(e) => setForm((p) => ({ ...p, name: e.target.value }))}
+          placeholder='e.g. "Counter 1"'
+        />
+
+        <Input
+          label="Code (optional)"
+          value={form.code}
+          onChange={(e) => setForm((p) => ({ ...p, code: e.target.value }))}
+          placeholder='e.g. "C1", "A-01"'
+        />
+      </div>
+
+      <Input
+        label="Services (comma separated)"
+        value={form.servicesText}
+        onChange={(e) => setForm((p) => ({ ...p, servicesText: e.target.value }))}
+        placeholder="e.g. Deposits, Loans, Customer Care"
+        hint="Example: Deposits, Loans, Customer Care"
+      />
+
+      {!!servicesPreview.length && (
+        <div className="flex flex-wrap gap-2">
+          {servicesPreview.map((s) => (
+            <Badge key={s} variant="default">
+              {s}
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between rounded-xl border border-gray-700/60 bg-gray-900/40 p-3">
+        <div>
+          <p className="text-sm font-medium text-gray-200">Active</p>
+          <p className="text-xs text-gray-400">
+            {form.isActive ? "Counter is active and usable" : "Counter is disabled"}
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setForm((p) => ({ ...p, isActive: !p.isActive }))}
+          className={[
+            "relative inline-flex h-6 w-11 items-center rounded-full transition",
+            form.isActive ? "bg-cyan-500/80" : "bg-gray-700",
+          ].join(" ")}
+          aria-label="Toggle active"
+        >
+          <span
+            className={[
+              "inline-block h-5 w-5 transform rounded-full bg-white transition",
+              form.isActive ? "translate-x-5" : "translate-x-1",
+            ].join(" ")}
+          />
+        </button>
+      </div>
+
+      <div className="flex justify-end gap-2 pt-2">
+        <Button type="button" variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={!canSubmit}>
+          {isEdit ? "Update Counter" : "Create Counter"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend-web/src/features/counter/components/CounterTable.tsx
+++ b/frontend-web/src/features/counter/components/CounterTable.tsx
@@ -1,0 +1,135 @@
+import type { ReactNode } from "react";
+import { Pencil, Trash2, Ban, CheckCircle } from "lucide-react";
+import Table from "../../../components/ui/Table";
+import Badge from "../../../components/ui/Badge";
+import Button from "../../../components/ui/Button";
+import type { CounterDto } from "../types";
+
+type Props = {
+  items: CounterDto[];
+  onEdit: (c: CounterDto) => void;
+  onDelete: (c: CounterDto) => void;
+  onToggleActive: (c: CounterDto) => void | Promise<void>;
+};
+
+export default function CounterTable({
+  items,
+  onEdit,
+  onDelete,
+  onToggleActive,
+}: Props) {
+  const columns: { header: string; cell: (row: CounterDto) => ReactNode; className?: string }[] =
+    [
+      {
+        header: "Counter",
+        cell: (c) => (
+          <div className="flex flex-col">
+            <span className="font-medium text-white">{c.name}</span>
+            <span className="text-xs text-gray-400">
+              {c.code ? `Code: ${c.code}` : "No code"}
+            </span>
+          </div>
+        ),
+      },
+      {
+        header: "Branch",
+        className: "w-[220px]",
+        cell: (c) => (
+          <div className="flex flex-col">
+            <span className="font-medium text-white">{c.branch?.name ?? "-"}</span>
+            <span className="text-xs text-gray-400">{c.branch?.code ?? "-"}</span>
+          </div>
+        ),
+      },
+      {
+        header: "Services",
+        cell: (c) => (
+          <div className="flex flex-wrap gap-2">
+            {(c.services ?? []).length ? (
+              c.services.slice(0, 3).map((s) => (
+                <Badge key={s} variant="default">
+                  {s}
+                </Badge>
+              ))
+            ) : (
+              <span className="text-sm text-gray-400">—</span>
+            )}
+            {(c.services ?? []).length > 3 && (
+              <span className="text-xs text-gray-400">
+                +{(c.services ?? []).length - 3} more
+              </span>
+            )}
+          </div>
+        ),
+      },
+      {
+        header: "Status",
+        className: "w-[140px]",
+        cell: (c) =>
+          c.isActive ? (
+            <Badge variant="success">Active</Badge>
+          ) : (
+            <Badge variant="danger">Inactive</Badge>
+          ),
+      },
+      {
+        header: "Actions",
+        className: "w-[220px] text-center",
+        cell: (c) => (
+          <div className="flex items-center justify-end gap-2 whitespace-nowrap">
+            <Button
+              variant="secondary"
+              onClick={() => onEdit(c)}
+              className="px-3"
+              title="Edit"
+            >
+              <Pencil className="h-4 w-4" />
+              <span className="hidden sm:inline">Edit</span>
+            </Button>
+
+            {c.isActive ? (
+              <Button
+                variant="danger"
+                onClick={() => void onToggleActive(c)}
+                className="px-3"
+                title="Deactivate"
+              >
+                <Ban className="h-4 w-4" />
+                <span className="hidden sm:inline">Deactivate</span>
+              </Button>
+            ) : (
+              <Button
+                variant="secondary"
+                onClick={() => void onToggleActive(c)}
+                className="px-5"
+                title="Activate"
+              >
+                <CheckCircle className="h-4 w-4" />
+                <span className="hidden sm:inline">Activate</span>
+              </Button>
+            )}
+
+            <Button
+              variant="danger"
+              onClick={() => onDelete(c)}
+              className="px-3"
+              title="Delete"
+            >
+              <Trash2 className="h-4 w-4" />
+              <span className="hidden sm:inline">Delete</span>
+            </Button>
+          </div>
+        ),
+      },
+    ];
+
+  return (
+    <Table
+      caption="Manage counters and their status"
+      columns={columns}
+      data={items}
+      keyField="_id"
+      emptyText="No counters yet. Create your first counter to get started."
+    />
+  );
+}

--- a/frontend-web/src/features/counter/index.ts
+++ b/frontend-web/src/features/counter/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export { default as CounterPage } from "./pages/CounterPage";

--- a/frontend-web/src/features/counter/pages/CounterPage.tsx
+++ b/frontend-web/src/features/counter/pages/CounterPage.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useMemo, useState } from "react";
+import { useAppDispatch, useAppSelector } from "../../../store/hooks";
+
+import {
+  fetchCounters,
+  createCounter,
+  updateCounter,
+  deleteCounter,
+  changeCounterStatus,
+} from "../../../store/slices/counter.slice";
+
+import { fetchBranches } from "../../../store/slices/branch.slice";
+
+import PageHeader from "../../../components/common/PageHeader";
+import Loading from "../../../components/common/Loading";
+import EmptyState from "../../../components/common/EmptyState";
+import Modal from "../../../components/ui/Modal";
+import ConfirmDialog from "../../../components/common/ConfirmDialog";
+import Button from "../../../components/ui/Button";
+import Badge from "../../../components/ui/Badge";
+
+import CounterTable from "../components/CounterTable";
+import CounterForm from "../components/CounterForm";
+import type { CounterDto } from "../types";
+
+export default function CounterPage() {
+  const dispatch = useAppDispatch();
+
+  const { items, loading, error } = useAppSelector((s) => s.counter);
+  const branches = useAppSelector((s) => s.branch.items);
+
+  const [openForm, setOpenForm] = useState(false);
+  const [editing, setEditing] = useState<CounterDto | null>(null);
+  const [toDelete, setToDelete] = useState<CounterDto | null>(null);
+
+  useEffect(() => {
+    dispatch(fetchCounters());
+    dispatch(fetchBranches(undefined));
+  }, [dispatch]);
+
+  const branchOptions = useMemo(
+    () => branches.map((b) => ({ label: b.name, value: b._id })),
+    [branches]
+  );
+
+  const canCreate = branchOptions.length > 0;
+
+  const activeCount = useMemo(
+    () => items.filter((c: CounterDto) => c.isActive).length,
+    [items]
+  );
+
+  const onCreate = () => {
+    setEditing(null);
+    setOpenForm(true);
+  };
+
+  const onEdit = (c: CounterDto) => {
+    setEditing(c);
+    setOpenForm(true);
+  };
+
+  const onSubmit = async (values: {
+    branchId: string;
+    name: string;
+    code: string | null;
+    services: string[];
+    isActive: boolean;
+  }) => {
+    if (editing?._id) {
+      const payload = {
+        name: values.name,
+        code: values.code,
+        services: values.services,
+        isActive: values.isActive,
+      };
+      await dispatch(updateCounter({ id: editing._id, payload })).unwrap();
+    } else {
+      await dispatch(createCounter(values)).unwrap();
+    }
+    setOpenForm(false);
+    setEditing(null);
+  };
+
+  const onToggleActive = async (c: CounterDto) => {
+    await dispatch(
+      changeCounterStatus({
+        id: c._id,
+        payload: { isActive: !c.isActive },
+      })
+    ).unwrap();
+  };
+
+  const onConfirmDelete = async () => {
+    if (!toDelete?._id) return;
+    await dispatch(deleteCounter(toDelete._id)).unwrap();
+    setToDelete(null);
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Counters"
+        subtitle={
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-gray-400">
+              Total: <span className="text-gray-200">{items.length}</span>
+            </span>
+            <span className="text-gray-600">•</span>
+            <span className="text-gray-400">
+              Active: <span className="text-gray-200">{activeCount}</span>
+            </span>
+            <Badge
+              variant={activeCount === items.length ? "success" : "warning"}
+              className="ml-2"
+            >
+              {activeCount}/{items.length} Active
+            </Badge>
+          </div>
+        }
+        right={
+          <Button onClick={onCreate} disabled={!canCreate}>
+            + New Counter
+          </Button>
+        }
+      />
+
+      {loading && <Loading />}
+
+      {!loading && error && (
+        <EmptyState
+          title="Something went wrong"
+          message={error ?? "Unknown error"}
+          action={<Button onClick={() => dispatch(fetchCounters())}>Retry</Button>}
+        />
+      )}
+
+      {!loading && !error && (
+        <>
+          {!canCreate && (
+            <div className="rounded-xl border border-gray-700/60 bg-gray-900/40 p-4 text-sm text-gray-300">
+              Branch list not loaded yet. Please create a branch first (or reload), then
+              you can add counters.
+            </div>
+          )}
+
+          {items.length === 0 ? (
+            <EmptyState
+              title="No counters yet"
+              message="Create your first counter to start managing service points."
+              action={
+                <Button onClick={onCreate} disabled={!canCreate}>
+                  + New Counter
+                </Button>
+              }
+            />
+          ) : (
+            <CounterTable
+              items={items}
+              onEdit={onEdit}
+              onDelete={(c) => setToDelete(c)}
+              onToggleActive={onToggleActive}
+            />
+          )}
+        </>
+      )}
+
+      <Modal
+        open={openForm}
+        onClose={() => {
+          setOpenForm(false);
+          setEditing(null);
+        }}
+        title={editing ? "Edit Counter" : "Create Counter"}
+      >
+        <CounterForm
+          initial={editing}
+          branchOptions={branchOptions}
+          submitting={loading}
+          onCancel={() => {
+            setOpenForm(false);
+            setEditing(null);
+          }}
+          onSubmit={onSubmit}
+        />
+      </Modal>
+
+      <ConfirmDialog
+        open={Boolean(toDelete)}
+        title="Delete counter"
+        message={`Delete "${toDelete?.name}"? This action cannot be undone.`}
+        confirmText="Delete"
+        cancelText="Cancel"
+        onClose={() => setToDelete(null)}
+        onConfirm={onConfirmDelete}
+      />
+    </div>
+  );
+}

--- a/frontend-web/src/features/counter/types.ts
+++ b/frontend-web/src/features/counter/types.ts
@@ -1,0 +1,53 @@
+export type CounterDto = {
+  _id: string;
+  branch: {
+    _id: string;
+    name: string;
+    code: string;
+  };
+  name: string;
+  code: string | null;
+  services: string[];
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CreateCounterDto = {
+  branchId: string;
+  name: string;
+  code?: string | null;
+  services?: string[];
+  isActive?: boolean;
+};
+
+export type UpdateCounterDto = Partial<{
+  name: string;
+  code: string | null;
+  services: string[];
+  isActive: boolean;
+}>;
+
+export type ChangeCounterStatusDto = {
+  isActive: boolean;
+};
+
+export type CounterFormValues = {
+  branchId: string;
+  name: string;
+  code: string;
+  servicesText: string;
+  isActive: boolean;
+};
+
+export type PaginationMeta = {
+  page: number;
+  limit: number;
+  total: number;
+  pages: number;
+};
+
+export type PaginatedResult<T> = {
+  items: T[];
+  pagination: PaginationMeta;
+};

--- a/frontend-web/src/store/slices/counter.slice.ts
+++ b/frontend-web/src/store/slices/counter.slice.ts
@@ -1,22 +1,169 @@
-import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import toast from "react-hot-toast";
+import { counterApi } from "../../features/counter/api/counter.api";
+import type {
+  CounterDto,
+  CreateCounterDto,
+  UpdateCounterDto,
+  ChangeCounterStatusDto,
+} from "../../features/counter/types";
 
-export interface CounterState {
-  list: unknown[];
-}
+type CounterState = {
+  items: CounterDto[];
+  selected: CounterDto | null;
+  loading: boolean;
+  error: string | null;
+};
 
 const initialState: CounterState = {
-  list: [],
+  items: [],
+  selected: null,
+  loading: false,
+  error: null,
 };
+
+export const fetchCounters = createAsyncThunk("counter/fetchCounters", async () => {
+  return await counterApi.list();
+});
+
+export const fetchCounterById = createAsyncThunk(
+  "counter/fetchCounterById",
+  async (id: string) => {
+    return await counterApi.getById(id);
+  }
+);
+
+export const createCounter = createAsyncThunk(
+  "counter/createCounter",
+  async (payload: CreateCounterDto) => {
+    return await counterApi.create(payload);
+  }
+);
+
+export const updateCounter = createAsyncThunk(
+  "counter/updateCounter",
+  async ({ id, payload }: { id: string; payload: UpdateCounterDto }) => {
+    return await counterApi.update(id, payload);
+  }
+);
+
+export const changeCounterStatus = createAsyncThunk(
+  "counter/changeCounterStatus",
+  async ({ id, payload }: { id: string; payload: ChangeCounterStatusDto }) => {
+    return await counterApi.changeStatus(id, payload);
+  }
+);
+
+export const deleteCounter = createAsyncThunk(
+  "counter/deleteCounter",
+  async (id: string) => {
+    await counterApi.remove(id);
+    return id; 
+  }
+);
 
 const counterSlice = createSlice({
   name: "counter",
   initialState,
   reducers: {
-    setCounters(state, action: PayloadAction<unknown[]>) {
-      state.list = action.payload;
+    clearSelectedCounter(state) {
+      state.selected = null;
     },
+  },
+  extraReducers: (builder) => {
+    builder
+      // fetch list
+      .addCase(fetchCounters.pending, (s) => {
+        s.loading = true;
+        s.error = null;
+      })
+      .addCase(fetchCounters.fulfilled, (s, a) => {
+        s.loading = false;
+        s.items = Array.isArray(a.payload) ? a.payload : [];
+      })
+      .addCase(fetchCounters.rejected, (s, a) => {
+        s.loading = false;
+        s.error = a.error.message || "Failed to load counters";
+      })
+
+      // fetch by id
+      .addCase(fetchCounterById.pending, (s) => {
+        s.loading = true;
+        s.error = null;
+      })
+      .addCase(fetchCounterById.fulfilled, (s, a) => {
+        s.loading = false;
+        s.selected = a.payload;
+      })
+      .addCase(fetchCounterById.rejected, (s, a) => {
+        s.loading = false;
+        s.error = a.error.message || "Failed to load counter";
+      })
+
+      // create
+      .addCase(createCounter.pending, (s) => {
+        s.loading = true;
+        s.error = null;
+      })
+      .addCase(createCounter.fulfilled, (s, a) => {
+        s.loading = false;
+        s.items = [a.payload, ...s.items];
+        toast.success("Counter created");
+      })
+      .addCase(createCounter.rejected, (s, a) => {
+        s.loading = false;
+        s.error = a.error.message || "Failed to create counter";
+      })
+
+      // update
+      .addCase(updateCounter.pending, (s) => {
+        s.loading = true;
+        s.error = null;
+      })
+      .addCase(updateCounter.fulfilled, (s, a) => {
+        s.loading = false;
+        s.items = s.items.map((c) => (c._id === a.payload._id ? a.payload : c));
+        if (s.selected?._id === a.payload._id) s.selected = a.payload;
+        toast.success("Counter updated");
+      })
+      .addCase(updateCounter.rejected, (s, a) => {
+        s.loading = false;
+        s.error = a.error.message || "Failed to update counter";
+      })
+
+      // status change
+      .addCase(changeCounterStatus.pending, (s) => {
+        s.loading = true;
+        s.error = null;
+      })
+      .addCase(changeCounterStatus.fulfilled, (s, a) => {
+        s.loading = false;
+        s.items = s.items.map((c) => (c._id === a.payload._id ? a.payload : c));
+        if (s.selected?._id === a.payload._id) s.selected = a.payload;
+        toast.success("Status updated");
+      })
+      .addCase(changeCounterStatus.rejected, (s, a) => {
+        s.loading = false;
+        s.error = a.error.message || "Failed to update status";
+      })
+
+      // delete
+      .addCase(deleteCounter.pending, (s) => {
+        s.loading = true;
+        s.error = null;
+      })
+      .addCase(deleteCounter.fulfilled, (s, a) => {
+        s.loading = false;
+        s.items = s.items.filter((c) => c._id !== a.payload);
+        if (s.selected?._id === a.payload) s.selected = null;
+        toast.success("Counter deleted");
+      })
+      .addCase(deleteCounter.rejected, (s, a) => {
+        s.loading = false;
+        s.error = a.error.message || "Failed to delete counter";
+      });
   },
 });
 
-export const { setCounters } = counterSlice.actions;
+export const { clearSelectedCounter } = counterSlice.actions;
 export default counterSlice.reducer;


### PR DESCRIPTION
###  Summary
This PR introduces the **Counter Management module** to the admin portal, enabling admins to fully manage service counters with a clean UI and robust backend integration.

Closes #55 .
---

### ✨ What’s Included

####  Frontend
- Counter Management page (`/admin/counters`)
- Create, update, delete, and activate/deactivate counters
- Counter form with branch selection and service mapping
- Counter table with status badges and action buttons
- Redux slice with async thunks and toast feedback
- Typed DTOs for counters and forms
- Centralized API layer and endpoint definitions
- Feature barrel exports for cleaner imports

####  Routing
- Added `counters` route to admin router

---

###  Backend (Related Changes)
- Populate branch (`name`, `code`) in counter responses
- Consistent populated responses on create/update/status
- Switched from soft delete to hard delete for counters

---

###  Acceptance Criteria
- Admin can view all counters
- Admin can create and update counters
- Admin can activate/deactivate counters
- Admin can delete counters
- Branch data is displayed correctly in counter list
- No console or TypeScript errors